### PR TITLE
Use rlp_03 instead, one eventloop per thread

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ Example Iterator will send only static records like as
 
 [source,sh]
 ----
-<14>1 2024-02-29T13:58:05.605Z localhost rlp_09 - - - Example rlo_09 event
+<14>1 2024-02-29T13:58:05.605Z localhost rlp_09 - - - Example rlo_09 record
 ----
 
 == Configurations

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <revision>0.0.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <sha1/>
-    <rlp_01.version>4.0.1</rlp_01.version>
+    <rlp_03.version>7.0.2</rlp_03.version>
   </properties>
   <licenses>
     <license>
@@ -40,8 +40,8 @@
     <!-- RELP -->
     <dependency>
       <groupId>com.teragrep</groupId>
-      <artifactId>rlp_01</artifactId>
-      <version>${rlp_01.version}</version>
+      <artifactId>rlp_03</artifactId>
+      <version>${rlp_03.version}</version>
     </dependency>
     <!-- Syslog message -->
     <dependency>

--- a/src/main/java/com/teragrep/rlp_09/ExampleRelpFlooderIterator.java
+++ b/src/main/java/com/teragrep/rlp_09/ExampleRelpFlooderIterator.java
@@ -62,7 +62,7 @@ public class ExampleRelpFlooderIterator implements Iterator<byte[]> {
                     .withHostname("localhost")
                     .withFacility(Facility.USER)
                     .withSeverity(Severity.INFORMATIONAL)
-                    .withMsg("Example rlo_09 event")
+                    .withMsg("Example rlo_09 record")
                     .toRfc5424SyslogMessage()
                     .getBytes(StandardCharsets.UTF_8);
     @Override

--- a/src/main/java/com/teragrep/rlp_09/RelpFlooder.java
+++ b/src/main/java/com/teragrep/rlp_09/RelpFlooder.java
@@ -49,7 +49,6 @@ package com.teragrep.rlp_09;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -58,32 +57,32 @@ public class RelpFlooder {
     private final ExecutorService executorService;
     List<RelpFlooderTask> relpFlooderTaskList = new ArrayList<>();
 
-    public HashMap<Integer, Integer> getRecordsSentPerThread() {
-        HashMap<Integer, Integer> recordsSent = new HashMap<>();
+    public HashMap<Integer, Long> getRecordsSentPerThread() {
+        HashMap<Integer, Long> recordsSent = new HashMap<>();
         for(RelpFlooderTask relpFlooderTask : relpFlooderTaskList){
             recordsSent.put(relpFlooderTask.getThreadId(), relpFlooderTask.getRecordsSent());
         }
         return recordsSent;
     }
 
-    public int getTotalRecordsSent() {
-        int totalrecordsSent = 0;
+    public long getTotalRecordsSent() {
+        long totalrecordsSent = 0;
         for(RelpFlooderTask relpFlooderTask : relpFlooderTaskList){
             totalrecordsSent += relpFlooderTask.getRecordsSent();
         }
         return totalrecordsSent;
     }
 
-    public HashMap<Integer, Integer> getTotalBytesSentPerThread() {
-        HashMap<Integer, Integer> bytesSent = new HashMap<>();
+    public HashMap<Integer, Long> getTotalBytesSentPerThread() {
+        HashMap<Integer, Long> bytesSent = new HashMap<>();
         for(RelpFlooderTask relpFlooderTask : relpFlooderTaskList){
             bytesSent.put(relpFlooderTask.getThreadId(), relpFlooderTask.getBytesSent());
         }
         return bytesSent;
     }
 
-    public int getTotalBytesSent() {
-        int totalBytesSent = 0;
+    public long getTotalBytesSent() {
+        long totalBytesSent = 0;
         for(RelpFlooderTask relpFlooderTask : relpFlooderTaskList){
             totalBytesSent += relpFlooderTask.getBytesSent();
         }

--- a/src/main/java/com/teragrep/rlp_09/RelpFlooderConfig.java
+++ b/src/main/java/com/teragrep/rlp_09/RelpFlooderConfig.java
@@ -51,6 +51,9 @@ public class RelpFlooderConfig {
     private String target="127.0.0.1";
     private int port=601;
     private int threads=1;
+    private int connectTimeout=1;
+
+    private boolean waitForAcks=true;
 
     public void setTarget(String target) {
         this.target = target;
@@ -62,6 +65,12 @@ public class RelpFlooderConfig {
 
     public void setThreads(int threads) {
         this.threads = threads;
+    }
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+    public void setWaitForAcks(boolean waitForAcks) {
+        this.waitForAcks = waitForAcks;
     }
 
     public String getTarget() {
@@ -76,12 +85,23 @@ public class RelpFlooderConfig {
         return threads;
     }
 
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public boolean getWaitForAcks() {
+        return waitForAcks;
+    }
+
     public RelpFlooderConfig() {
     }
 
-    public RelpFlooderConfig(String target, int port, int threads) {
+    public RelpFlooderConfig(String target, int port, int threads, int connectTimeout, boolean waitForAcks) {
         this.target = target;
         this.port = port;
         this.threads = threads;
+        this.connectTimeout = connectTimeout;
+        this.waitForAcks = waitForAcks;
     }
+
 }


### PR DESCRIPTION
Uses rlp_03 for client, adds connectTimeout and waitForAcks features
Changes byte/record counting to long as int overflow is easily possible